### PR TITLE
Megaparsec 7 Compatibility Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lambdacube-compiler-test-suite.tix
 .ghc.environment.*
 .dir-locals.el
 .stack-work
+cabal.project


### PR DESCRIPTION
Some of these were simply function naming changes. P.State was updated to take an extra (ErrorFancy Void) parameter. Other than that, the changes were mostly updating ParseError to (NonEmpty ParseError), as  `runParse'` now returns a ParseErrorBundle; the other field of which is simply discarded.