### PR TITLE
Fix as-pattern for GHC 9

### DIFF
--- a/src/LambdaCube/Compiler/Lexer.hs
+++ b/src/LambdaCube/Compiler/Lexer.hs
@@ -318,7 +318,7 @@ calcPrec
 calcPrec app getFixity = compileOps []
   where
     compileOps [] e [] = return e
-    compileOps acc@ ~((op', e'): acc') e es@ ~((op, e''): es')
+    compileOps acc@(~((op', e'): acc')) e es@(~((op, e''): es'))
         | c == LT || c == EQ && isInfixL f && isInfixL f' = compileOps acc' (app op' e' e) es
         | c == GT || c == EQ && isInfixR f && isInfixR f' = compileOps ((op, e): acc) e'' es'
         | otherwise = throwError (op', op)  -- operator mismatch


### PR DESCRIPTION
Based on the below; resolves an error, "Suffix occurrence of @. For an as-pattern, remove the leading whitespace."

https://stackoverflow.com/questions/67972231/syntax-for-lazy-pattern-matching-with-as-syntax

https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#whitespace-sensitive-and-

With the combination of #19, #21 and this, the binary builds on current GHC and dependency package set versions.